### PR TITLE
Tweak navbars styling

### DIFF
--- a/doc/pytch/pytch-page-footer.html
+++ b/doc/pytch/pytch-page-footer.html
@@ -1,10 +1,10 @@
     <div id="navigation-strip">
       <p>
         <span class="nav-item"><a href="/pytch.html">Home</a></span>
-        <span class="nav-item"><a href="/pytch-doc/help.html">Help</a></span>
-        <span class="nav-item"><a href="/pytch-doc/about.html">About</a></span>
-        <span class="nav-item"><a href="mailto:info@pytch.org">Contact</a></span>
         <span class="nav-item"><a href="https://github.com/bennorth/pytch/tree/pytch-prototype">GitHub</a></span>
+        <span class="nav-item"><a href="mailto:info@pytch.org">Contact</a></span>
+        <span class="nav-item"><a href="/pytch-doc/about.html">About</a></span>
+        <span class="nav-item"><a href="/pytch-doc/help.html">Help</a></span>
       </p>
     </div>
   </body>

--- a/doc/pytch/pytch-page-footer.html
+++ b/doc/pytch/pytch-page-footer.html
@@ -1,6 +1,6 @@
     <div id="navigation-strip">
       <p>
-        <span class="nav-item"><a href="/pytch.html">Home</a></span>
+        <span class="nav-item at-left"><a href="/pytch.html">Home</a></span>
         <span class="nav-item"><a href="https://github.com/bennorth/pytch/tree/pytch-prototype">GitHub</a></span>
         <span class="nav-item"><a href="mailto:info@pytch.org">Contact</a></span>
         <span class="nav-item"><a href="/pytch-doc/about.html">About</a></span>

--- a/example/pytch-gui.css
+++ b/example/pytch-gui.css
@@ -115,10 +115,12 @@ span.nav-item a {
 }
 
 #navigation-strip span.nav-item a:hover {
+    text-decoration: none;
     background-color: #66a;
 }
 
 #editor-menubar span.nav-item a:hover {
+    text-decoration: none;
     background-color: #336;
 }
 

--- a/example/pytch-gui.css
+++ b/example/pytch-gui.css
@@ -114,6 +114,10 @@ span.nav-item a {
     background-color: #66a;
 }
 
+#editor-menubar span.nav-item a:hover {
+    background-color: #336;
+}
+
 #skulpt-out-err-container { clear: both; }
 
 #skulpt-out-err-container ul.tabs {

--- a/example/pytch-gui.css
+++ b/example/pytch-gui.css
@@ -99,6 +99,10 @@ span.nav-item {
     float: right;
 }
 
+span.nav-item.at-left {
+    float: none;
+}
+
 #navigation-strip span.nav-item:first-child {
     padding-left: 2.5em;
 }

--- a/example/pytch.html
+++ b/example/pytch.html
@@ -33,10 +33,10 @@
       class="menu-elt project-name" value="Untitled"></input>
         <span id="compile-button" class="menu-elt">COMPILE</span>
 
-        <span class="nav-item"><a href="/pytch-doc/help.html">Help</a></span>
-        <span class="nav-item"><a href="/pytch-doc/about.html">About</a></span>
-        <span class="nav-item"><a href="mailto:info@pytch.org">Contact</a></span>
         <span class="nav-item" ><a href="https://github.com/bennorth/pytch/">Github</a></span>
+        <span class="nav-item"><a href="mailto:info@pytch.org">Contact</a></span>
+        <span class="nav-item"><a href="/pytch-doc/about.html">About</a></span>
+        <span class="nav-item"><a href="/pytch-doc/help.html">Help</a></span>
 
 
       </p>


### PR DESCRIPTION
Re-order elements to match original.  (Display order is mirror of source order because of right-float behaviour.)  Ensure no underlining.  Give on-hover highlights of opposite blue.  Put 'Home' to left of footer.